### PR TITLE
chore: default to react client for everyone

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,5 @@ jobs:
       - run: nohup bash -c "npm start 2>&1 &" && sleep 4
         env:
           TESTMODE: 1
+          CLIENT_VERSION: backbone
       - run: npx cypress run

--- a/code/src/routerClient.ts
+++ b/code/src/routerClient.ts
@@ -49,19 +49,24 @@ let clientIndexHtmlBackbone = '';
 let clientIndexHtmlReact = '';
 const cacheClientIndexHtml = true;
 
-// Route to enable React client
+function shouldUseBackbone(req: Request): boolean {
+  return req.cookies?.['client-version'] === 'backbone' ||
+         process.env.CLIENT_VERSION === 'backbone';
+}
+
+// Route to enable React client (default)
 router.get('/use-react', (_req: Request, res: Response) => {
-  res.cookie('client-version', 'react', {
+  res.clearCookie('client-version');
+  res.redirect('/');
+});
+
+// Route to opt back into the legacy Backbone client
+router.get('/use-backbone', (_req: Request, res: Response) => {
+  res.cookie('client-version', 'backbone', {
     maxAge: 365 * 24 * 60 * 60 * 1000, // 1 year
     httpOnly: true,
     sameSite: 'lax',
   });
-  res.redirect('/');
-});
-
-// Route to enable Backbone client (default)
-router.get('/use-backbone', (_req: Request, res: Response) => {
-  res.clearCookie('client-version');
   res.redirect('/');
 });
 
@@ -70,20 +75,18 @@ router.get('/', (req: Request, res: Response) => {
     return res.redirect('/auth/google');
   }
 
-  // Check cookie to determine which client to serve
-  const useReact = (req.cookies?.['client-version'] === 'react') || 
-                   (process.env.CLIENT_VERSION === 'react');
-  const clientDir = useReact ? clientDirs[1] : clientDirs[0];
-  const cachedHtml = useReact ? clientIndexHtmlReact : clientIndexHtmlBackbone;
+  const useBackbone = shouldUseBackbone(req);
+  const clientDir = useBackbone ? clientDirs[0] : clientDirs[1];
+  const cachedHtml = useBackbone ? clientIndexHtmlBackbone : clientIndexHtmlReact;
 
   if (!cachedHtml || !cacheClientIndexHtml) {
     const indexPath = path.join(basePath, clientDir, 'index.html');
     fs.readFile(indexPath, { encoding: 'utf-8' }, (err, data) => {
       if (!err) {
-        if (useReact) {
-          clientIndexHtmlReact = data;
-        } else {
+        if (useBackbone) {
           clientIndexHtmlBackbone = data;
+        } else {
+          clientIndexHtmlReact = data;
         }
         res.send(data);
 
@@ -133,10 +136,7 @@ if (Config.testMode) {
   ));
 
   router.get('/loginTest', (req: Request, res: Response) => {
-    // Use React client for test mode by default, but respect cookie
-    const useReact = (req.cookies?.['client-version'] === 'react') || 
-                     (process.env.CLIENT_VERSION === 'react');
-    const clientDir = useReact ? clientDirs[1] : clientDirs[0];
+    const clientDir = shouldUseBackbone(req) ? clientDirs[0] : clientDirs[1];
     const testLoginPath = path.join(basePath, clientDir, 'test', 'login.html');
     res.sendFile(testLoginPath);
   });


### PR DESCRIPTION
## Summary
- Flips the cookie/env logic in `routerClient`: no cookie or env override now serves the React client.
- `/use-backbone` sets `client-version=backbone` to opt back into the legacy client; `/use-react` clears the cookie to return to the default.
- Sets `CLIENT_VERSION=backbone` in the Backbone Cypress workflow so it keeps exercising the legacy client.

## Caveat
Users who previously visited `/use-backbone` had their cookie cleared (that's how the old code expressed the Backbone preference). After this change, a cleared cookie means React — so those users will silently flip to React. They can re-opt in by visiting `/use-backbone` once. There's no server-side state to migrate this automatically.

## Test plan
- [ ] Fresh user (no cookie) hits `/` → served React client.
- [ ] Visit `/use-backbone` → redirected to `/`, served Backbone client; cookie `client-version=backbone` is set.
- [ ] Visit `/use-react` → redirected to `/`, served React client; cookie is cleared.
- [ ] `CLIENT_VERSION=backbone` env var forces the Backbone client.
- [ ] Both Cypress workflows pass (`test.yml` Backbone, `test-react.yml` React).

🤖 Generated with [Claude Code](https://claude.com/claude-code)