### PR TITLE
feat: file uploads in waves

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,4 @@ jobs:
         env:
           TESTMODE: 1
           CLIENT_VERSION: backbone
-      - run: npx cypress run
+      - run: npx cypress run --env CLIENT_VERSION=backbone

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ report/
 client/dist/
 code/dist/
 uploads/
+dump.rdb

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ report/
 .DS_Store
 client/dist/
 code/dist/
+uploads/

--- a/client-react/src/components/MessageItem.tsx
+++ b/client-react/src/components/MessageItem.tsx
@@ -217,27 +217,27 @@ const MessageItem = memo(function MessageItem({
             </td>
           </tr>
           
-          {message.attachment && (() => {
-            const downloadUrl = `/wave/${message.waveId}/file/${message._id}`
-            const isImage = message.attachment.mimeType.startsWith('image/') && shouldShowPictures
+          {message.attachments?.map(att => {
+            const downloadUrl = `/wave/${message.waveId}/file/${message._id}/${att.storageKey}`
+            const isImage = att.mimeType.startsWith('image/') && shouldShowPictures
             return (
-              <tr>
+              <tr key={att.storageKey}>
                 <td className="message-header"></td>
                 <td className="message-attachment message-body">
                   {isImage ? (
                     <a href={downloadUrl} target="_blank" rel="noreferrer">
-                      <img src={downloadUrl} className="message-img" alt={message.attachment.filename} />
+                      <img src={downloadUrl} className="message-img" alt={att.filename} />
                     </a>
                   ) : (
                     <a href={downloadUrl} target="_blank" rel="noreferrer" className="attachment-card">
-                      📎 {message.attachment.filename}{' '}
-                      <span className="attachment-size">({formatBytes(message.attachment.size)})</span>
+                      📎 {att.filename}{' '}
+                      <span className="attachment-size">({formatBytes(att.size)})</span>
                     </a>
                   )}
                 </td>
               </tr>
             )
-          })()}
+          })}
 
           {message.linkPreview && shouldShowLinkPreview && (
             <tr>

--- a/client-react/src/components/MessageItem.tsx
+++ b/client-react/src/components/MessageItem.tsx
@@ -15,6 +15,12 @@ const URL_PICTURE_REGEX = /\.(jpg|png|gif)(\?.*)?$/i
 const URL_VIDEO_REGEX = /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]+).*/i
 const URL_VIDEO_REGEX_YOUTUBE = /.*youtu.*/i
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
 function parseMessageContent(
   text: string,
   shouldShowPictures: boolean,
@@ -211,6 +217,28 @@ const MessageItem = memo(function MessageItem({
             </td>
           </tr>
           
+          {message.attachment && (() => {
+            const downloadUrl = `/wave/${message.waveId}/file/${message._id}`
+            const isImage = message.attachment.mimeType.startsWith('image/') && shouldShowPictures
+            return (
+              <tr>
+                <td className="message-header"></td>
+                <td className="message-attachment message-body">
+                  {isImage ? (
+                    <a href={downloadUrl} target="_blank" rel="noreferrer">
+                      <img src={downloadUrl} className="message-img" alt={message.attachment.filename} />
+                    </a>
+                  ) : (
+                    <a href={downloadUrl} target="_blank" rel="noreferrer" className="attachment-card">
+                      📎 {message.attachment.filename}{' '}
+                      <span className="attachment-size">({formatBytes(message.attachment.size)})</span>
+                    </a>
+                  )}
+                </td>
+              </tr>
+            )
+          })()}
+
           {message.linkPreview && shouldShowLinkPreview && (
             <tr>
               <td className="message-header"></td>

--- a/client-react/src/components/MessageReplyForm.tsx
+++ b/client-react/src/components/MessageReplyForm.tsx
@@ -79,7 +79,11 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? [])
-    if (files.length > 0) addFiles(files)
+    const images = files.filter(f => f.type.startsWith('image/'))
+    if (images.length < files.length) {
+      alert(t('Only image files are allowed'))
+    }
+    if (images.length > 0) addFiles(images)
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
@@ -88,7 +92,7 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
     if (!items) return
     const pasted: File[] = []
     for (const item of items) {
-      if (item.kind === 'file') {
+      if (item.kind === 'file' && item.type.startsWith('image/')) {
         const file = item.getAsFile()
         if (file) pasted.push(file)
       }
@@ -138,6 +142,7 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
           <input
             ref={fileInputRef}
             type="file"
+            accept="image/*"
             multiple
             style={{ display: 'none' }}
             onChange={handleFileChange}
@@ -148,7 +153,7 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
             className="button attach R"
             onClick={() => fileInputRef.current?.click()}
             disabled={uploading || atLimit}
-            title={atLimit ? t('Maximum 10 files') : t('Attach file')}
+            title={atLimit ? t('Maximum 10 files') : t('Attach image')}
           >
             📎
           </button>

--- a/client-react/src/components/MessageReplyForm.tsx
+++ b/client-react/src/components/MessageReplyForm.tsx
@@ -12,10 +12,19 @@ interface Props {
   onCancel: () => void
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
 export default function MessageReplyForm({ message, onCancel }: Props) {
   const [replyMessage, setReplyMessage] = useState('')
+  const [pendingFile, setPendingFile] = useState<File | null>(null)
+  const [uploading, setUploading] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
   const messageUser = useUserStore(state => {
     const user = state.getUser(message.userId)
     return user || { name: 'Unknown' }
@@ -26,14 +35,29 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
     textareaRef.current?.focus()
   }, [])
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
+    if (uploading) return
+
+    if (pendingFile) {
+      setUploading(true)
+      try {
+        await communicator.uploadFile(pendingFile, message.waveId, replyMessage, message._id)
+        setPendingFile(null)
+        setReplyMessage('')
+        if (fileInputRef.current) fileInputRef.current.value = ''
+      } catch (err) {
+        alert((err as Error).message)
+      } finally {
+        setUploading(false)
+        textareaRef.current?.focus()
+      }
+      return
+    }
+
     if (!replyMessage.trim()) return
-    
     communicator.sendMessage(replyMessage, message.waveId, message._id)
     setReplyMessage('')
-    
-    // Keep the form open and refocus
     textareaRef.current?.focus()
   }
 
@@ -45,6 +69,16 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
       e.preventDefault()
       mentionUser(textareaRef.current, replyMessage, setReplyMessage, waveUsers)
     }
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) setPendingFile(file)
+  }
+
+  const clearFile = () => {
+    setPendingFile(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
   return (
@@ -60,13 +94,36 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
           value={replyMessage}
           onChange={(e) => setReplyMessage(e.target.value)}
           name="message"
-          placeholder={`${t('Reply to message')} ${messageUser.name}`}
+          placeholder={pendingFile ? t('Add caption (optional)') : `${t('Reply to message')} ${messageUser.name}`}
           className="R"
           onKeyDown={handleKeyDown}
+          disabled={uploading}
         />
+        {pendingFile && (
+          <p className="attachment-chip">
+            📎 {pendingFile.name} ({formatBytes(pendingFile.size)})
+            <a href="#" className="button cancel" onClick={(e) => { e.preventDefault(); clearFile() }}>✕</a>
+          </p>
+        )}
         <p className="inline-help mhide">
-          <button type="submit" className="button sendmsg R">
-            {t('Save message')}
+          <input
+            ref={fileInputRef}
+            type="file"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+            disabled={uploading}
+          />
+          <button
+            type="button"
+            className="button attach R"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            title={t('Attach file')}
+          >
+            📎
+          </button>
+          <button type="submit" className="button sendmsg R" disabled={uploading || (!pendingFile && !replyMessage.trim())}>
+            {uploading ? t('Uploading...') : t('Save message')}
           </button>
           <span className="R hint">{t('Press Return to send, Shift-Return to break line.')}</span>
         </p>

--- a/client-react/src/components/MessageReplyForm.tsx
+++ b/client-react/src/components/MessageReplyForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, FormEvent, KeyboardEvent } from 'react'
+import { useState, useRef, useEffect, ClipboardEvent, FormEvent, KeyboardEvent } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { Message } from '@/types'
 import { useUserStore } from '@/stores/userStore'
@@ -6,6 +6,8 @@ import { useWaveStore } from '@/stores/waveStore'
 import { communicator } from '@/services/communicator'
 import { t } from '@/utils/i18n'
 import { mentionUser } from '@/utils/mentionUser'
+
+const MAX_FILES = 10
 
 interface Props {
   message: Message
@@ -20,7 +22,7 @@ function formatBytes(bytes: number): string {
 
 export default function MessageReplyForm({ message, onCancel }: Props) {
   const [replyMessage, setReplyMessage] = useState('')
-  const [pendingFile, setPendingFile] = useState<File | null>(null)
+  const [pendingFiles, setPendingFiles] = useState<File[]>([])
   const [uploading, setUploading] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -35,15 +37,19 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
     textareaRef.current?.focus()
   }, [])
 
+  const addFiles = (incoming: File[]) => {
+    setPendingFiles(prev => [...prev, ...incoming].slice(0, MAX_FILES))
+  }
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     if (uploading) return
 
-    if (pendingFile) {
+    if (pendingFiles.length > 0) {
       setUploading(true)
       try {
-        await communicator.uploadFile(pendingFile, message.waveId, replyMessage, message._id)
-        setPendingFile(null)
+        await communicator.uploadFiles(pendingFiles, message.waveId, replyMessage, message._id)
+        setPendingFiles([])
         setReplyMessage('')
         if (fileInputRef.current) fileInputRef.current.value = ''
       } catch (err) {
@@ -72,14 +78,32 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
   }
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (file) setPendingFile(file)
-  }
-
-  const clearFile = () => {
-    setPendingFile(null)
+    const files = Array.from(e.target.files ?? [])
+    if (files.length > 0) addFiles(files)
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
+
+  const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = e.clipboardData?.items
+    if (!items) return
+    const pasted: File[] = []
+    for (const item of items) {
+      if (item.kind === 'file') {
+        const file = item.getAsFile()
+        if (file) pasted.push(file)
+      }
+    }
+    if (pasted.length > 0) {
+      e.preventDefault()
+      addFiles(pasted)
+    }
+  }
+
+  const removeFile = (idx: number) => {
+    setPendingFiles(prev => prev.filter((_, i) => i !== idx))
+  }
+
+  const atLimit = pendingFiles.length >= MAX_FILES
 
   return (
     <div className="notification replyform">
@@ -94,21 +118,27 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
           value={replyMessage}
           onChange={(e) => setReplyMessage(e.target.value)}
           name="message"
-          placeholder={pendingFile ? t('Add caption (optional)') : `${t('Reply to message')} ${messageUser.name}`}
+          placeholder={pendingFiles.length > 0 ? t('Add caption (optional)') : `${t('Reply to message')} ${messageUser.name}`}
           className="R"
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           disabled={uploading}
         />
-        {pendingFile && (
-          <p className="attachment-chip">
-            📎 {pendingFile.name} ({formatBytes(pendingFile.size)})
-            <a href="#" className="button cancel" onClick={(e) => { e.preventDefault(); clearFile() }}>✕</a>
-          </p>
+        {pendingFiles.length > 0 && (
+          <ul className="attachment-chips">
+            {pendingFiles.map((f, i) => (
+              <li key={`${f.name}-${i}`} className="attachment-chip">
+                📎 {f.name} ({formatBytes(f.size)})
+                <a href="#" className="button cancel" onClick={(e) => { e.preventDefault(); removeFile(i) }}>✕</a>
+              </li>
+            ))}
+          </ul>
         )}
         <p className="inline-help mhide">
           <input
             ref={fileInputRef}
             type="file"
+            multiple
             style={{ display: 'none' }}
             onChange={handleFileChange}
             disabled={uploading}
@@ -117,12 +147,16 @@ export default function MessageReplyForm({ message, onCancel }: Props) {
             type="button"
             className="button attach R"
             onClick={() => fileInputRef.current?.click()}
-            disabled={uploading}
-            title={t('Attach file')}
+            disabled={uploading || atLimit}
+            title={atLimit ? t('Maximum 10 files') : t('Attach file')}
           >
             📎
           </button>
-          <button type="submit" className="button sendmsg R" disabled={uploading || (!pendingFile && !replyMessage.trim())}>
+          <button
+            type="submit"
+            className="button sendmsg R"
+            disabled={uploading || (pendingFiles.length === 0 && !replyMessage.trim())}
+          >
             {uploading ? t('Uploading...') : t('Save message')}
           </button>
           <span className="R hint">{t('Press Return to send, Shift-Return to break line.')}</span>

--- a/client-react/src/components/WaveReplyForm.tsx
+++ b/client-react/src/components/WaveReplyForm.tsx
@@ -1,9 +1,11 @@
-import { useState, useRef, FormEvent, KeyboardEvent } from 'react'
+import { useState, useRef, ClipboardEvent, FormEvent, KeyboardEvent } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { communicator } from '@/services/communicator'
 import { useWaveStore } from '@/stores/waveStore'
 import { t } from '@/utils/i18n'
 import { mentionUser } from '@/utils/mentionUser'
+
+const MAX_FILES = 10
 
 interface Props {
   waveId: string
@@ -17,21 +19,25 @@ function formatBytes(bytes: number): string {
 
 export default function WaveReplyForm({ waveId }: Props) {
   const [message, setMessage] = useState('')
-  const [pendingFile, setPendingFile] = useState<File | null>(null)
+  const [pendingFiles, setPendingFiles] = useState<File[]>([])
   const [uploading, setUploading] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const waveUsers = useWaveStore(useShallow(state => state.getWaveUsers(waveId)))
 
+  const addFiles = (incoming: File[]) => {
+    setPendingFiles(prev => [...prev, ...incoming].slice(0, MAX_FILES))
+  }
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     if (uploading) return
 
-    if (pendingFile) {
+    if (pendingFiles.length > 0) {
       setUploading(true)
       try {
-        await communicator.uploadFile(pendingFile, waveId, message, null)
-        setPendingFile(null)
+        await communicator.uploadFiles(pendingFiles, waveId, message, null)
+        setPendingFiles([])
         setMessage('')
         if (fileInputRef.current) fileInputRef.current.value = ''
       } catch (err) {
@@ -60,14 +66,32 @@ export default function WaveReplyForm({ waveId }: Props) {
   }
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (file) setPendingFile(file)
-  }
-
-  const clearFile = () => {
-    setPendingFile(null)
+    const files = Array.from(e.target.files ?? [])
+    if (files.length > 0) addFiles(files)
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
+
+  const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = e.clipboardData?.items
+    if (!items) return
+    const pasted: File[] = []
+    for (const item of items) {
+      if (item.kind === 'file') {
+        const file = item.getAsFile()
+        if (file) pasted.push(file)
+      }
+    }
+    if (pasted.length > 0) {
+      e.preventDefault()
+      addFiles(pasted)
+    }
+  }
+
+  const removeFile = (idx: number) => {
+    setPendingFiles(prev => prev.filter((_, i) => i !== idx))
+  }
+
+  const atLimit = pendingFiles.length >= MAX_FILES
 
   return (
     <div className="notification replyform">
@@ -77,21 +101,27 @@ export default function WaveReplyForm({ waveId }: Props) {
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           name="message"
-          placeholder={pendingFile ? t('Add caption (optional)') : t('Add message')}
+          placeholder={pendingFiles.length > 0 ? t('Add caption (optional)') : t('Add message')}
           className="R"
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           disabled={uploading}
         />
-        {pendingFile && (
-          <p className="attachment-chip">
-            📎 {pendingFile.name} ({formatBytes(pendingFile.size)})
-            <a href="#" className="button cancel" onClick={(e) => { e.preventDefault(); clearFile() }}>✕</a>
-          </p>
+        {pendingFiles.length > 0 && (
+          <ul className="attachment-chips">
+            {pendingFiles.map((f, i) => (
+              <li key={`${f.name}-${i}`} className="attachment-chip">
+                📎 {f.name} ({formatBytes(f.size)})
+                <a href="#" className="button cancel" onClick={(e) => { e.preventDefault(); removeFile(i) }}>✕</a>
+              </li>
+            ))}
+          </ul>
         )}
         <p className="inline-help mhide">
           <input
             ref={fileInputRef}
             type="file"
+            multiple
             style={{ display: 'none' }}
             onChange={handleFileChange}
             disabled={uploading}
@@ -100,12 +130,16 @@ export default function WaveReplyForm({ waveId }: Props) {
             type="button"
             className="button attach R"
             onClick={() => fileInputRef.current?.click()}
-            disabled={uploading}
-            title={t('Attach file')}
+            disabled={uploading || atLimit}
+            title={atLimit ? t('Maximum 10 files') : t('Attach file')}
           >
             📎
           </button>
-          <button type="submit" className="button sendmsg R" disabled={uploading || (!pendingFile && !message.trim())}>
+          <button
+            type="submit"
+            className="button sendmsg R"
+            disabled={uploading || (pendingFiles.length === 0 && !message.trim())}
+          >
             {uploading ? t('Uploading...') : t('Save message')}
           </button>
           <span className="R hint">{t('Press Return to send, Shift-Return to break line.')}</span>

--- a/client-react/src/components/WaveReplyForm.tsx
+++ b/client-react/src/components/WaveReplyForm.tsx
@@ -67,7 +67,11 @@ export default function WaveReplyForm({ waveId }: Props) {
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? [])
-    if (files.length > 0) addFiles(files)
+    const images = files.filter(f => f.type.startsWith('image/'))
+    if (images.length < files.length) {
+      alert(t('Only image files are allowed'))
+    }
+    if (images.length > 0) addFiles(images)
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
@@ -76,7 +80,7 @@ export default function WaveReplyForm({ waveId }: Props) {
     if (!items) return
     const pasted: File[] = []
     for (const item of items) {
-      if (item.kind === 'file') {
+      if (item.kind === 'file' && item.type.startsWith('image/')) {
         const file = item.getAsFile()
         if (file) pasted.push(file)
       }
@@ -121,6 +125,7 @@ export default function WaveReplyForm({ waveId }: Props) {
           <input
             ref={fileInputRef}
             type="file"
+            accept="image/*"
             multiple
             style={{ display: 'none' }}
             onChange={handleFileChange}
@@ -131,7 +136,7 @@ export default function WaveReplyForm({ waveId }: Props) {
             className="button attach R"
             onClick={() => fileInputRef.current?.click()}
             disabled={uploading || atLimit}
-            title={atLimit ? t('Maximum 10 files') : t('Attach file')}
+            title={atLimit ? t('Maximum 10 files') : t('Attach image')}
           >
             📎
           </button>

--- a/client-react/src/components/WaveReplyForm.tsx
+++ b/client-react/src/components/WaveReplyForm.tsx
@@ -9,19 +9,43 @@ interface Props {
   waveId: string
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
 export default function WaveReplyForm({ waveId }: Props) {
   const [message, setMessage] = useState('')
+  const [pendingFile, setPendingFile] = useState<File | null>(null)
+  const [uploading, setUploading] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const waveUsers = useWaveStore(useShallow(state => state.getWaveUsers(waveId)))
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
+    if (uploading) return
+
+    if (pendingFile) {
+      setUploading(true)
+      try {
+        await communicator.uploadFile(pendingFile, waveId, message, null)
+        setPendingFile(null)
+        setMessage('')
+        if (fileInputRef.current) fileInputRef.current.value = ''
+      } catch (err) {
+        alert((err as Error).message)
+      } finally {
+        setUploading(false)
+        textareaRef.current?.focus()
+      }
+      return
+    }
+
     if (!message.trim()) return
-    
     communicator.sendMessage(message, waveId, null)
     setMessage('')
-    
-    // Keep the form open and refocus
     textareaRef.current?.focus()
   }
 
@@ -35,6 +59,16 @@ export default function WaveReplyForm({ waveId }: Props) {
     }
   }
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) setPendingFile(file)
+  }
+
+  const clearFile = () => {
+    setPendingFile(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
   return (
     <div className="notification replyform">
       <form className="add-message" method="post" onSubmit={handleSubmit}>
@@ -43,13 +77,36 @@ export default function WaveReplyForm({ waveId }: Props) {
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           name="message"
-          placeholder={t('Add message')}
+          placeholder={pendingFile ? t('Add caption (optional)') : t('Add message')}
           className="R"
           onKeyDown={handleKeyDown}
+          disabled={uploading}
         />
+        {pendingFile && (
+          <p className="attachment-chip">
+            📎 {pendingFile.name} ({formatBytes(pendingFile.size)})
+            <a href="#" className="button cancel" onClick={(e) => { e.preventDefault(); clearFile() }}>✕</a>
+          </p>
+        )}
         <p className="inline-help mhide">
-          <button type="submit" className="button sendmsg R">
-            {t('Save message')}
+          <input
+            ref={fileInputRef}
+            type="file"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+            disabled={uploading}
+          />
+          <button
+            type="button"
+            className="button attach R"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            title={t('Attach file')}
+          >
+            📎
+          </button>
+          <button type="submit" className="button sendmsg R" disabled={uploading || (!pendingFile && !message.trim())}>
+            {uploading ? t('Uploading...') : t('Save message')}
           </button>
           <span className="R hint">{t('Press Return to send, Shift-Return to break line.')}</span>
         </p>

--- a/client-react/src/services/communicator.ts
+++ b/client-react/src/services/communicator.ts
@@ -88,6 +88,29 @@ class Communicator {
     this.socket.emit('message', msg)
   }
 
+  async uploadFile(
+    file: File,
+    waveId: string,
+    caption: string,
+    parentId: string | null
+  ): Promise<void> {
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('caption', caption)
+    if (parentId) formData.append('parentId', parentId)
+
+    const res = await fetch(`/wave/${waveId}/upload`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData
+    })
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({ error: 'Upload failed' }))
+      throw new Error(body.error || `Upload failed (${res.status})`)
+    }
+  }
+
   readMessage(messageId: string, waveId: string) {
     if (!this.socket) return
 
@@ -155,7 +178,8 @@ class Communicator {
       message: msgData.message,
       parentId: msgData.parentId,
       created_at: createdAt,
-      unread: isOwnMessage ? false : (msgData.unread ?? true)
+      unread: isOwnMessage ? false : (msgData.unread ?? true),
+      attachment: msgData.attachment
     }
 
     const wave = waveStore.getWave(msgData.waveId)

--- a/client-react/src/services/communicator.ts
+++ b/client-react/src/services/communicator.ts
@@ -88,14 +88,14 @@ class Communicator {
     this.socket.emit('message', msg)
   }
 
-  async uploadFile(
-    file: File,
+  async uploadFiles(
+    files: File[],
     waveId: string,
     caption: string,
     parentId: string | null
   ): Promise<void> {
     const formData = new FormData()
-    formData.append('file', file)
+    for (const f of files) formData.append('file', f)
     formData.append('caption', caption)
     if (parentId) formData.append('parentId', parentId)
 
@@ -179,7 +179,7 @@ class Communicator {
       parentId: msgData.parentId,
       created_at: createdAt,
       unread: isOwnMessage ? false : (msgData.unread ?? true),
-      attachment: msgData.attachment
+      attachments: msgData.attachments
     }
 
     const wave = waveStore.getWave(msgData.waveId)

--- a/client-react/src/types/index.ts
+++ b/client-react/src/types/index.ts
@@ -17,6 +17,13 @@ export interface Wave {
   current?: boolean
 }
 
+export interface Attachment {
+  storageKey: string
+  filename: string
+  mimeType: string
+  size: number
+}
+
 export interface Message {
   _id: string
   userId: string
@@ -26,6 +33,7 @@ export interface Message {
   created_at: number
   unread: boolean
   linkPreview?: LinkPreview
+  attachment?: Attachment
 }
 
 export interface LinkPreview {
@@ -49,6 +57,7 @@ export interface SocketMessageData {
   parentId: string | null
   created_at: number | string // Can be timestamp or Date string from server
   unread?: boolean
+  attachment?: Attachment
   messages?: SocketMessageData[]
 }
 

--- a/client-react/src/types/index.ts
+++ b/client-react/src/types/index.ts
@@ -33,7 +33,7 @@ export interface Message {
   created_at: number
   unread: boolean
   linkPreview?: LinkPreview
-  attachment?: Attachment
+  attachments?: Attachment[]
 }
 
 export interface LinkPreview {
@@ -57,7 +57,7 @@ export interface SocketMessageData {
   parentId: string | null
   created_at: number | string // Can be timestamp or Date string from server
   unread?: boolean
-  attachment?: Attachment
+  attachments?: Attachment[]
   messages?: SocketMessageData[]
 }
 

--- a/client-react/vite.config.ts
+++ b/client-react/vite.config.ts
@@ -20,20 +20,7 @@ export default defineConfig({
   },
   server: {
     port: 3002,
-    open: true,
-    hmr: { port: 3003 },
-    proxy: {
-      '/socket.io': { target: 'http://localhost:8000', ws: true, rewriteWsOrigin: true },
-      '/wave':      { target: 'http://localhost:8000', changeOrigin: true },
-      '/auth':      { target: 'http://localhost:8000', changeOrigin: true },
-      '/loginTest': { target: 'http://localhost:8000', changeOrigin: true },
-      '/logoutTest':{ target: 'http://localhost:8000', changeOrigin: true },
-      '/logout':    { target: 'http://localhost:8000', changeOrigin: true },
-      '/invite':    { target: 'http://localhost:8000', changeOrigin: true },
-      '/logError':  { target: 'http://localhost:8000', changeOrigin: true },
-      '/use-react':    { target: 'http://localhost:8000', changeOrigin: true },
-      '/use-backbone': { target: 'http://localhost:8000', changeOrigin: true },
-    },
+    open: true
   },
   resolve: {
     alias: {

--- a/client-react/vite.config.ts
+++ b/client-react/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     open: true,
     hmr: { port: 3003 },
     proxy: {
-      '/socket.io': { target: 'ws://localhost:8000', ws: true, rewriteWsOrigin: true },
+      '/socket.io': { target: 'http://localhost:8000', ws: true, rewriteWsOrigin: true },
       '/wave':      { target: 'http://localhost:8000', changeOrigin: true },
       '/auth':      { target: 'http://localhost:8000', changeOrigin: true },
       '/loginTest': { target: 'http://localhost:8000', changeOrigin: true },

--- a/client-react/vite.config.ts
+++ b/client-react/vite.config.ts
@@ -20,7 +20,19 @@ export default defineConfig({
   },
   server: {
     port: 3002,
-    open: true
+    open: true,
+    proxy: {
+      '/socket.io': { target: 'http://localhost:8000', ws: true, changeOrigin: true },
+      '/wave':      { target: 'http://localhost:8000', changeOrigin: true },
+      '/auth':      { target: 'http://localhost:8000', changeOrigin: true },
+      '/loginTest': { target: 'http://localhost:8000', changeOrigin: true },
+      '/logoutTest':{ target: 'http://localhost:8000', changeOrigin: true },
+      '/logout':    { target: 'http://localhost:8000', changeOrigin: true },
+      '/invite':    { target: 'http://localhost:8000', changeOrigin: true },
+      '/logError':  { target: 'http://localhost:8000', changeOrigin: true },
+      '/use-react':    { target: 'http://localhost:8000', changeOrigin: true },
+      '/use-backbone': { target: 'http://localhost:8000', changeOrigin: true },
+    },
   },
   resolve: {
     alias: {

--- a/client-react/vite.config.ts
+++ b/client-react/vite.config.ts
@@ -21,8 +21,9 @@ export default defineConfig({
   server: {
     port: 3002,
     open: true,
+    hmr: { port: 3003 },
     proxy: {
-      '/socket.io': { target: 'http://localhost:8000', ws: true, changeOrigin: true },
+      '/socket.io': { target: 'ws://localhost:8000', ws: true, rewriteWsOrigin: true },
       '/wave':      { target: 'http://localhost:8000', changeOrigin: true },
       '/auth':      { target: 'http://localhost:8000', changeOrigin: true },
       '/loginTest': { target: 'http://localhost:8000', changeOrigin: true },

--- a/code/src/Config.ts
+++ b/code/src/Config.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type { Config } from './types.js';
 
 const config: Config = {
@@ -9,6 +10,8 @@ const config: Config = {
   hostName: process.env.HOSTNAME || '',
   testMode: Boolean(process.env.TESTMODE) || false,
   port: Number(process.env.PORT) || 8000,
+  uploadDir: process.env.UPLOAD_DIR || path.join(process.cwd(), 'uploads'),
+  maxUploadBytes: Number(process.env.MAX_UPLOAD_BYTES) || 10 * 1024 * 1024,
 };
 
 export default config;

--- a/code/src/DAL.ts
+++ b/code/src/DAL.ts
@@ -114,7 +114,7 @@ class DataAccessLayer {
       waveId: new Types.ObjectId(message.waveId),
       parentId: message.parentId ? new Types.ObjectId(message.parentId) : null,
       message: message.message,
-      attachment: message.attachment,
+      attachments: message.attachments,
       created_at: new Date(message.created_at),
     });
 
@@ -363,7 +363,7 @@ class DataAccessLayer {
       waveId: mmsg.waveId.toString(),
       parentId: mmsg.parentId?.toString() ?? null,
       message: mmsg.message,
-      attachment: mmsg.attachment,
+      attachments: mmsg.attachments,
       unread: unreadIds.includes(mmsg._id.toString()),
       created_at: mmsg.created_at.getTime(),
     }));

--- a/code/src/DAL.ts
+++ b/code/src/DAL.ts
@@ -114,6 +114,7 @@ class DataAccessLayer {
       waveId: new Types.ObjectId(message.waveId),
       parentId: message.parentId ? new Types.ObjectId(message.parentId) : null,
       message: message.message,
+      attachment: message.attachment,
       created_at: new Date(message.created_at),
     });
 
@@ -362,6 +363,7 @@ class DataAccessLayer {
       waveId: mmsg.waveId.toString(),
       parentId: mmsg.parentId?.toString() ?? null,
       message: mmsg.message,
+      attachment: mmsg.attachment,
       unread: unreadIds.includes(mmsg._id.toString()),
       created_at: mmsg.created_at.getTime(),
     }));

--- a/code/src/ExpressServer.ts
+++ b/code/src/ExpressServer.ts
@@ -6,6 +6,7 @@ import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
 import session from 'express-session';
 import routerClient from './routerClient.js';
+import routerUploads from './routerUploads.js';
 import cors from 'cors';
 import type { GoogleProfile } from './types.js';
 
@@ -56,6 +57,7 @@ export function startExpressServer(): http.Server {
   app.use(passport.initialize());
   app.use(passport.session());
 
+  app.use('/', routerUploads);
   app.use('/', routerClient);
 
   return http.createServer(app);

--- a/code/src/MongooseModels.ts
+++ b/code/src/MongooseModels.ts
@@ -24,7 +24,7 @@ const MessageSchema = new Schema<MessageDocument>({
   parentId: { type: Schema.Types.ObjectId, ref: 'MessageModel', default: null },
   rootId: { type: Schema.Types.ObjectId, ref: 'MessageModel', default: null },
   message: { type: String, trim: true },
-  attachment: { type: AttachmentSchema, default: undefined },
+  attachments: { type: [AttachmentSchema], default: undefined },
   created_at: { type: Date }
 });
 

--- a/code/src/MongooseModels.ts
+++ b/code/src/MongooseModels.ts
@@ -11,12 +11,20 @@ const UserSchema = new Schema<UserDocument>({
   email: { type: String, trim: true }
 });
 
+const AttachmentSchema = new Schema({
+  storageKey: { type: String, required: true },
+  filename: { type: String, required: true },
+  mimeType: { type: String, required: true },
+  size: { type: Number, required: true }
+}, { _id: false });
+
 const MessageSchema = new Schema<MessageDocument>({
   userId: { type: Schema.Types.ObjectId, ref: 'UserModel' },
   waveId: { type: Schema.Types.ObjectId, ref: 'WaveModel' },
   parentId: { type: Schema.Types.ObjectId, ref: 'MessageModel', default: null },
   rootId: { type: Schema.Types.ObjectId, ref: 'MessageModel', default: null },
   message: { type: String, trim: true },
+  attachment: { type: AttachmentSchema, default: undefined },
   created_at: { type: Date }
 });
 

--- a/code/src/Storage.ts
+++ b/code/src/Storage.ts
@@ -1,0 +1,45 @@
+import fs from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+import Config from './Config.js';
+
+class LocalDiskStorage {
+  get uploadDir(): string {
+    return Config.uploadDir;
+  }
+
+  pathFor(waveId: string, storageKey: string): string {
+    return path.join(this.uploadDir, waveId, storageKey);
+  }
+
+  async ensureWaveDir(waveId: string): Promise<string> {
+    const dir = path.join(this.uploadDir, waveId);
+    await fs.mkdir(dir, { recursive: true });
+    return dir;
+  }
+
+  generateKey(): string {
+    return crypto.randomBytes(16).toString('hex');
+  }
+
+  async exists(waveId: string, storageKey: string): Promise<boolean> {
+    try {
+      await fs.access(this.pathFor(waveId, storageKey));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async delete(waveId: string, storageKey: string): Promise<void> {
+    try {
+      await fs.unlink(this.pathFor(waveId, storageKey));
+    } catch {
+      // ignore
+    }
+  }
+}
+
+const Storage = new LocalDiskStorage();
+export default Storage;
+export { LocalDiskStorage };

--- a/code/src/model/Message.ts
+++ b/code/src/model/Message.ts
@@ -6,7 +6,7 @@ export class Message {
   waveId: string;
   parentId: string | null;
   message: string;
-  attachment?: AttachmentData;
+  attachments?: AttachmentData[];
   unread: boolean;
   created_at: number;
 
@@ -16,7 +16,7 @@ export class Message {
     this.waveId = data?.waveId ?? '';
     this.parentId = data?.parentId ?? null;
     this.message = data?.message ?? '';
-    this.attachment = data?.attachment;
+    this.attachments = data?.attachments;
     this.unread = data?.unread ?? true;
     this.created_at = data?.created_at ?? Date.now();
   }
@@ -34,7 +34,8 @@ export class Message {
   }
 
   validate(): string | undefined {
-    if (this.message.trim().length === 0 && !this.attachment) {
+    const hasAttachments = (this.attachments?.length ?? 0) > 0;
+    if (this.message.trim().length === 0 && !hasAttachments) {
       return 'Empty message';
     }
     return undefined;
@@ -51,7 +52,7 @@ export class Message {
       waveId: this.waveId,
       parentId: this.parentId,
       message: this.message,
-      attachment: this.attachment,
+      attachments: this.attachments,
       unread: this.unread,
       created_at: this.created_at,
     };

--- a/code/src/model/Message.ts
+++ b/code/src/model/Message.ts
@@ -1,4 +1,4 @@
-import type { MessageData } from '../types.js';
+import type { AttachmentData, MessageData } from '../types.js';
 
 export class Message {
   private _id: string | undefined;
@@ -6,6 +6,7 @@ export class Message {
   waveId: string;
   parentId: string | null;
   message: string;
+  attachment?: AttachmentData;
   unread: boolean;
   created_at: number;
 
@@ -15,6 +16,7 @@ export class Message {
     this.waveId = data?.waveId ?? '';
     this.parentId = data?.parentId ?? null;
     this.message = data?.message ?? '';
+    this.attachment = data?.attachment;
     this.unread = data?.unread ?? true;
     this.created_at = data?.created_at ?? Date.now();
   }
@@ -32,7 +34,7 @@ export class Message {
   }
 
   validate(): string | undefined {
-    if (this.message.trim().length === 0) {
+    if (this.message.trim().length === 0 && !this.attachment) {
       return 'Empty message';
     }
     return undefined;
@@ -49,6 +51,7 @@ export class Message {
       waveId: this.waveId,
       parentId: this.parentId,
       message: this.message,
+      attachment: this.attachment,
       unread: this.unread,
       created_at: this.created_at,
     };

--- a/code/src/routerUploads.ts
+++ b/code/src/routerUploads.ts
@@ -21,6 +21,8 @@ const INLINE_MIMES = new Set([
 
 const router = express.Router();
 
+const MAX_FILES_PER_MESSAGE = 10;
+
 const upload = multer({
   storage: multer.diskStorage({
     destination: (req, _file, cb) => {
@@ -33,7 +35,7 @@ const upload = multer({
       cb(null, Storage.generateKey());
     },
   }),
-  limits: { fileSize: Config.maxUploadBytes, files: 1 },
+  limits: { fileSize: Config.maxUploadBytes, files: MAX_FILES_PER_MESSAGE },
 });
 
 async function resolveWaveMember(
@@ -83,16 +85,19 @@ function encodeContentDisposition(disposition: 'inline' | 'attachment', filename
 router.post(
   '/wave/:waveId/upload',
   resolveWaveMember,
-  upload.single('file'),
+  upload.array('file', MAX_FILES_PER_MESSAGE),
   async (req: Request, res: Response) => {
-    const file = req.file;
-    if (!file) {
+    const files = (req.files ?? []) as Express.Multer.File[];
+    const surfUserId = (req as Request & { surfUserId: string }).surfUserId;
+    const surfWaveId = (req as Request & { surfWaveId: string }).surfWaveId;
+
+    const cleanup = () => Promise.all(files.map(f => Storage.delete(surfWaveId, f.filename)));
+
+    if (files.length === 0) {
       res.status(400).json({ error: 'No file provided' });
       return;
     }
 
-    const surfUserId = (req as Request & { surfUserId: string }).surfUserId;
-    const surfWaveId = (req as Request & { surfWaveId: string }).surfWaveId;
     const caption = typeof req.body.caption === 'string' ? req.body.caption : '';
     const parentIdRaw = typeof req.body.parentId === 'string' ? req.body.parentId : '';
     const parentId = parentIdRaw && Types.ObjectId.isValid(parentIdRaw) ? parentIdRaw : null;
@@ -101,7 +106,7 @@ router.post(
       const { default: SurfServer } = await import('./SurfServer.js');
       const wave = SurfServer.waves.get(surfWaveId);
       if (!wave) {
-        await Storage.delete(surfWaveId, file.filename);
+        await cleanup();
         res.status(404).json({ error: 'Wave not found' });
         return;
       }
@@ -111,16 +116,16 @@ router.post(
         waveId: surfWaveId,
         parentId,
         message: caption,
-        attachment: {
-          storageKey: file.filename,
-          filename: file.originalname,
-          mimeType: file.mimetype,
-          size: file.size,
-        },
+        attachments: files.map(f => ({
+          storageKey: f.filename,
+          filename: f.originalname,
+          mimeType: f.mimetype,
+          size: f.size,
+        })),
       });
 
       if (!msg.isValid()) {
-        await Storage.delete(surfWaveId, file.filename);
+        await cleanup();
         res.status(400).json({ error: 'Invalid message' });
         return;
       }
@@ -128,7 +133,7 @@ router.post(
       await wave.addMessage(msg);
       res.status(201).json(msg.toJSON());
     } catch (err) {
-      await Storage.delete(surfWaveId, file.filename);
+      await cleanup();
       console.log('UPLOAD ERROR', err);
       res.status(500).json({ error: 'Upload failed' });
     }
@@ -136,23 +141,33 @@ router.post(
 );
 
 router.get(
-  '/wave/:waveId/file/:messageId',
+  '/wave/:waveId/file/:messageId/:storageKey',
   resolveWaveMember,
   async (req: Request, res: Response) => {
-    const messageId = req.params.messageId;
+    const { messageId, storageKey } = req.params;
     if (!Types.ObjectId.isValid(messageId)) {
       res.status(400).json({ error: 'Invalid messageId' });
+      return;
+    }
+    if (!/^[a-f0-9]{32}$/.test(storageKey)) {
+      res.status(400).json({ error: 'Invalid storageKey' });
       return;
     }
 
     const surfWaveId = (req as Request & { surfWaveId: string }).surfWaveId;
     const msgDoc = await MessageModel.findById(messageId).exec();
-    if (!msgDoc || msgDoc.waveId.toString() !== surfWaveId || !msgDoc.attachment) {
+    if (!msgDoc || msgDoc.waveId.toString() !== surfWaveId) {
       res.status(404).json({ error: 'File not found' });
       return;
     }
 
-    const { storageKey, filename, mimeType, size } = msgDoc.attachment;
+    const attachment = msgDoc.attachments?.find(a => a.storageKey === storageKey);
+    if (!attachment) {
+      res.status(404).json({ error: 'File not found' });
+      return;
+    }
+
+    const { filename, mimeType, size } = attachment;
     const filePath = Storage.pathFor(surfWaveId, storageKey);
 
     if (!(await Storage.exists(surfWaveId, storageKey))) {

--- a/code/src/routerUploads.ts
+++ b/code/src/routerUploads.ts
@@ -22,6 +22,7 @@ const INLINE_MIMES = new Set([
 const router = express.Router();
 
 const MAX_FILES_PER_MESSAGE = 10;
+const UNSUPPORTED_FILE_TYPE = 'UNSUPPORTED_FILE_TYPE';
 
 const upload = multer({
   storage: multer.diskStorage({
@@ -35,6 +36,15 @@ const upload = multer({
       cb(null, Storage.generateKey());
     },
   }),
+  fileFilter: (_req, file, cb) => {
+    if (file.mimetype.startsWith('image/')) {
+      cb(null, true);
+    } else {
+      const err = new Error('Only image files are allowed') as Error & { code: string };
+      err.code = UNSUPPORTED_FILE_TYPE;
+      cb(err);
+    }
+  },
   limits: { fileSize: Config.maxUploadBytes, files: MAX_FILES_PER_MESSAGE },
 });
 
@@ -187,13 +197,17 @@ router.get(
   }
 );
 
-router.use((err: Error, _req: Request, res: Response, next: NextFunction) => {
+router.use((err: Error & { code?: string }, _req: Request, res: Response, next: NextFunction) => {
   if (err instanceof multer.MulterError) {
     if (err.code === 'LIMIT_FILE_SIZE') {
       res.status(413).json({ error: 'File too large' });
       return;
     }
     res.status(400).json({ error: err.message });
+    return;
+  }
+  if (err.code === UNSUPPORTED_FILE_TYPE) {
+    res.status(415).json({ error: err.message });
     return;
   }
   next(err);

--- a/code/src/routerUploads.ts
+++ b/code/src/routerUploads.ts
@@ -1,0 +1,187 @@
+import express, { Request, Response, NextFunction } from 'express';
+import multer from 'multer';
+import { Types } from 'mongoose';
+import fs from 'fs';
+import Config from './Config.js';
+import Storage from './Storage.js';
+import { MessageModel } from './MongooseModels.js';
+import { Message } from './model/Message.js';
+import type { GoogleProfile } from './types.js';
+
+const INLINE_MIMES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'video/mp4',
+  'audio/mpeg',
+  'audio/mp4',
+  'application/pdf',
+]);
+
+const router = express.Router();
+
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: (req, _file, cb) => {
+      const waveId = req.params.waveId;
+      Storage.ensureWaveDir(waveId)
+        .then(dir => cb(null, dir))
+        .catch(err => cb(err as Error, ''));
+    },
+    filename: (_req, _file, cb) => {
+      cb(null, Storage.generateKey());
+    },
+  }),
+  limits: { fileSize: Config.maxUploadBytes, files: 1 },
+});
+
+async function resolveWaveMember(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  if (!req.isAuthenticated()) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
+  }
+
+  const waveId = req.params.waveId;
+  if (!waveId || !Types.ObjectId.isValid(waveId)) {
+    res.status(400).json({ error: 'Invalid waveId' });
+    return;
+  }
+
+  const { default: SurfServer } = await import('./SurfServer.js');
+  const wave = SurfServer.waves.get(waveId);
+  if (!wave) {
+    res.status(404).json({ error: 'Wave not found' });
+    return;
+  }
+
+  const passportUser = req.user as GoogleProfile;
+  const email = passportUser.emails?.[0]?.value;
+  const surfUser = SurfServer.users.find(u =>
+    u.googleId === passportUser.id || (email !== undefined && u.email === email)
+  );
+
+  if (!surfUser || !wave.isMember(surfUser)) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+
+  (req as Request & { surfUserId: string; surfWaveId: string }).surfUserId = surfUser.id;
+  (req as Request & { surfUserId: string; surfWaveId: string }).surfWaveId = wave.id;
+  next();
+}
+
+function encodeContentDisposition(disposition: 'inline' | 'attachment', filename: string): string {
+  const safeAscii = filename.replace(/[\\"\x00-\x1f\x7f]/g, '_');
+  return `${disposition}; filename="${safeAscii}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+}
+
+router.post(
+  '/wave/:waveId/upload',
+  resolveWaveMember,
+  upload.single('file'),
+  async (req: Request, res: Response) => {
+    const file = req.file;
+    if (!file) {
+      res.status(400).json({ error: 'No file provided' });
+      return;
+    }
+
+    const surfUserId = (req as Request & { surfUserId: string }).surfUserId;
+    const surfWaveId = (req as Request & { surfWaveId: string }).surfWaveId;
+    const caption = typeof req.body.caption === 'string' ? req.body.caption : '';
+    const parentIdRaw = typeof req.body.parentId === 'string' ? req.body.parentId : '';
+    const parentId = parentIdRaw && Types.ObjectId.isValid(parentIdRaw) ? parentIdRaw : null;
+
+    try {
+      const { default: SurfServer } = await import('./SurfServer.js');
+      const wave = SurfServer.waves.get(surfWaveId);
+      if (!wave) {
+        await Storage.delete(surfWaveId, file.filename);
+        res.status(404).json({ error: 'Wave not found' });
+        return;
+      }
+
+      const msg = new Message({
+        userId: surfUserId,
+        waveId: surfWaveId,
+        parentId,
+        message: caption,
+        attachment: {
+          storageKey: file.filename,
+          filename: file.originalname,
+          mimeType: file.mimetype,
+          size: file.size,
+        },
+      });
+
+      if (!msg.isValid()) {
+        await Storage.delete(surfWaveId, file.filename);
+        res.status(400).json({ error: 'Invalid message' });
+        return;
+      }
+
+      await wave.addMessage(msg);
+      res.status(201).json(msg.toJSON());
+    } catch (err) {
+      await Storage.delete(surfWaveId, file.filename);
+      console.log('UPLOAD ERROR', err);
+      res.status(500).json({ error: 'Upload failed' });
+    }
+  }
+);
+
+router.get(
+  '/wave/:waveId/file/:messageId',
+  resolveWaveMember,
+  async (req: Request, res: Response) => {
+    const messageId = req.params.messageId;
+    if (!Types.ObjectId.isValid(messageId)) {
+      res.status(400).json({ error: 'Invalid messageId' });
+      return;
+    }
+
+    const surfWaveId = (req as Request & { surfWaveId: string }).surfWaveId;
+    const msgDoc = await MessageModel.findById(messageId).exec();
+    if (!msgDoc || msgDoc.waveId.toString() !== surfWaveId || !msgDoc.attachment) {
+      res.status(404).json({ error: 'File not found' });
+      return;
+    }
+
+    const { storageKey, filename, mimeType, size } = msgDoc.attachment;
+    const filePath = Storage.pathFor(surfWaveId, storageKey);
+
+    if (!(await Storage.exists(surfWaveId, storageKey))) {
+      res.status(404).json({ error: 'File missing on storage' });
+      return;
+    }
+
+    const safeMime = INLINE_MIMES.has(mimeType) ? mimeType : 'application/octet-stream';
+    const disposition = INLINE_MIMES.has(mimeType) ? 'inline' : 'attachment';
+    res.setHeader('Content-Type', safeMime);
+    res.setHeader('Content-Length', String(size));
+    res.setHeader('Content-Disposition', encodeContentDisposition(disposition, filename));
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Cache-Control', 'private, max-age=3600');
+
+    fs.createReadStream(filePath).pipe(res);
+  }
+);
+
+router.use((err: Error, _req: Request, res: Response, next: NextFunction) => {
+  if (err instanceof multer.MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      res.status(413).json({ error: 'File too large' });
+      return;
+    }
+    res.status(400).json({ error: err.message });
+    return;
+  }
+  next(err);
+});
+
+export default router;

--- a/code/src/types.ts
+++ b/code/src/types.ts
@@ -144,6 +144,8 @@ export interface Config {
   hostName: string;
   testMode: boolean;
   port: number;
+  uploadDir: string;
+  maxUploadBytes: number;
 }
 
 // ============================================================================

--- a/code/src/types.ts
+++ b/code/src/types.ts
@@ -35,6 +35,13 @@ export interface WaveData {
   userIds: string[];
 }
 
+export interface AttachmentData {
+  storageKey: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+
 export interface MessageData {
   _id?: string;
   userId: string;
@@ -42,6 +49,7 @@ export interface MessageData {
   parentId: string | null;
   rootId?: string | null;
   message: string;
+  attachment?: AttachmentData;
   unread?: boolean;
   created_at: number;
 }
@@ -111,6 +119,7 @@ export interface MessageDocument {
   parentId: Types.ObjectId | null;
   rootId: Types.ObjectId | null;
   message: string;
+  attachment?: AttachmentData;
   created_at: Date;
 }
 

--- a/code/src/types.ts
+++ b/code/src/types.ts
@@ -49,7 +49,7 @@ export interface MessageData {
   parentId: string | null;
   rootId?: string | null;
   message: string;
-  attachment?: AttachmentData;
+  attachments?: AttachmentData[];
   unread?: boolean;
   created_at: number;
 }
@@ -119,7 +119,7 @@ export interface MessageDocument {
   parentId: Types.ObjectId | null;
   rootId: Types.ObjectId | null;
   message: string;
-  attachment?: AttachmentData;
+  attachments?: AttachmentData[];
   created_at: Date;
 }
 

--- a/code/tests/Storage.test.ts
+++ b/code/tests/Storage.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import Config from '../src/Config.js';
+import Storage from '../src/Storage.js';
+
+describe('Storage (local disk)', () => {
+  let tmpRoot: string;
+  let originalUploadDir: string;
+
+  beforeAll(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'surf-storage-test-'));
+    originalUploadDir = Config.uploadDir;
+    Config.uploadDir = tmpRoot;
+  });
+
+  afterAll(async () => {
+    Config.uploadDir = originalUploadDir;
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('generates unique storage keys', () => {
+    const keys = new Set(Array.from({ length: 100 }, () => Storage.generateKey()));
+    expect(keys.size).toBe(100);
+    for (const k of keys) {
+      expect(k).toMatch(/^[0-9a-f]{32}$/);
+    }
+  });
+
+  it('creates wave directory on ensureWaveDir', async () => {
+    const dir = await Storage.ensureWaveDir('wave-A');
+    expect(dir).toBe(path.join(tmpRoot, 'wave-A'));
+    const stat = await fs.stat(dir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('round-trips a file: write, exists, delete', async () => {
+    const waveId = 'wave-B';
+    const key = Storage.generateKey();
+    await Storage.ensureWaveDir(waveId);
+    const filePath = Storage.pathFor(waveId, key);
+
+    await fs.writeFile(filePath, 'hello world');
+
+    expect(await Storage.exists(waveId, key)).toBe(true);
+    const contents = await fs.readFile(filePath, 'utf-8');
+    expect(contents).toBe('hello world');
+
+    await Storage.delete(waveId, key);
+    expect(await Storage.exists(waveId, key)).toBe(false);
+  });
+
+  it('delete on missing file is a no-op', async () => {
+    await expect(Storage.delete('wave-C', 'does-not-exist')).resolves.toBeUndefined();
+  });
+
+  it('pathFor namespaces files under wave id', () => {
+    expect(Storage.pathFor('wave-X', 'foo')).toBe(path.join(tmpRoot, 'wave-X', 'foo'));
+    expect(Storage.pathFor('wave-Y', 'foo')).toBe(path.join(tmpRoot, 'wave-Y', 'foo'));
+  });
+});

--- a/code/tests/model/Message.test.ts
+++ b/code/tests/model/Message.test.ts
@@ -84,57 +84,62 @@ describe('Message', () => {
       expect(message.validate()).toBeUndefined();
     });
 
-    it('should return undefined when only attachment is present', () => {
+    it('should return undefined when only attachments are present', () => {
       const message = new Message({
         message: '',
-        attachment: {
+        attachments: [{
           storageKey: 'abc123',
           filename: 'photo.jpg',
           mimeType: 'image/jpeg',
           size: 1234,
-        },
+        }],
       });
       expect(message.validate()).toBeUndefined();
     });
 
-    it('should return undefined when both attachment and caption are present', () => {
+    it('should return error for empty attachments array with no text', () => {
+      const message = new Message({ message: '', attachments: [] });
+      expect(message.validate()).toBe('Empty message');
+    });
+
+    it('should return undefined for multiple attachments', () => {
+      const message = new Message({
+        message: '',
+        attachments: [
+          { storageKey: 'k1', filename: 'a.jpg', mimeType: 'image/jpeg', size: 1 },
+          { storageKey: 'k2', filename: 'b.jpg', mimeType: 'image/jpeg', size: 2 },
+        ],
+      });
+      expect(message.validate()).toBeUndefined();
+    });
+
+    it('should return undefined when both attachments and caption are present', () => {
       const message = new Message({
         message: 'Look at this',
-        attachment: {
+        attachments: [{
           storageKey: 'abc123',
           filename: 'photo.jpg',
           mimeType: 'image/jpeg',
           size: 1234,
-        },
+        }],
       });
       expect(message.validate()).toBeUndefined();
     });
   });
 
-  describe('toJSON with attachment', () => {
-    it('should include attachment when present', () => {
-      const message = new Message({
-        userId: 'u1',
-        waveId: 'w1',
-        message: '',
-        attachment: {
-          storageKey: 'key',
-          filename: 'a.pdf',
-          mimeType: 'application/pdf',
-          size: 42,
-        },
-      });
-      expect(message.toJSON().attachment).toEqual({
-        storageKey: 'key',
-        filename: 'a.pdf',
-        mimeType: 'application/pdf',
-        size: 42,
-      });
+  describe('toJSON with attachments', () => {
+    it('should include attachments array when present', () => {
+      const atts = [
+        { storageKey: 'k1', filename: 'a.pdf', mimeType: 'application/pdf', size: 42 },
+        { storageKey: 'k2', filename: 'b.png', mimeType: 'image/png', size: 99 },
+      ];
+      const message = new Message({ userId: 'u1', waveId: 'w1', message: '', attachments: atts });
+      expect(message.toJSON().attachments).toEqual(atts);
     });
 
-    it('should omit attachment when absent', () => {
+    it('should omit attachments when absent', () => {
       const message = new Message({ message: 'hi' });
-      expect(message.toJSON().attachment).toBeUndefined();
+      expect(message.toJSON().attachments).toBeUndefined();
     });
   });
 

--- a/code/tests/model/Message.test.ts
+++ b/code/tests/model/Message.test.ts
@@ -83,6 +83,59 @@ describe('Message', () => {
       const message = new Message({ message: 'Hello' });
       expect(message.validate()).toBeUndefined();
     });
+
+    it('should return undefined when only attachment is present', () => {
+      const message = new Message({
+        message: '',
+        attachment: {
+          storageKey: 'abc123',
+          filename: 'photo.jpg',
+          mimeType: 'image/jpeg',
+          size: 1234,
+        },
+      });
+      expect(message.validate()).toBeUndefined();
+    });
+
+    it('should return undefined when both attachment and caption are present', () => {
+      const message = new Message({
+        message: 'Look at this',
+        attachment: {
+          storageKey: 'abc123',
+          filename: 'photo.jpg',
+          mimeType: 'image/jpeg',
+          size: 1234,
+        },
+      });
+      expect(message.validate()).toBeUndefined();
+    });
+  });
+
+  describe('toJSON with attachment', () => {
+    it('should include attachment when present', () => {
+      const message = new Message({
+        userId: 'u1',
+        waveId: 'w1',
+        message: '',
+        attachment: {
+          storageKey: 'key',
+          filename: 'a.pdf',
+          mimeType: 'application/pdf',
+          size: 42,
+        },
+      });
+      expect(message.toJSON().attachment).toEqual({
+        storageKey: 'key',
+        filename: 'a.pdf',
+        mimeType: 'application/pdf',
+        size: 42,
+      });
+    });
+
+    it('should omit attachment when absent', () => {
+      const message = new Message({ message: 'hi' });
+      expect(message.toJSON().attachment).toBeUndefined();
+    });
   });
 
   describe('isValid', () => {

--- a/cypress/e2e/upload.spec.cy.js
+++ b/cypress/e2e/upload.spec.cy.js
@@ -1,0 +1,78 @@
+// Requires the React client. CI passes CLIENT_VERSION via `cypress run --env`
+// so we can skip cleanly when Backbone is in use; locally the default is React.
+const isBackbone = Cypress.env('CLIENT_VERSION') === 'backbone'
+const describeIfReact = isBackbone ? describe.skip : describe
+
+const userId = Date.now() + 100
+// Smallest possible valid 1x1 transparent PNG.
+const tinyPngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+
+const pngFile = (fileName) => ({
+    contents: Cypress.Buffer.from(tinyPngBase64, 'base64'),
+    fileName,
+    mimeType: 'image/png',
+})
+
+describeIfReact('file upload', () => {
+    it('uploads images with caption and renders them inline', () => {
+        cy.visit('http://localhost:8000/loginTest')
+        cy.get('input[name="username"]').type(`${userId}{enter}`)
+
+        cy.get('#wave-list a.addwave').click()
+        cy.get('#editwave').should('be.visible')
+        cy.get('#editwave form input#editwave-title').type('Upload Test{enter}')
+        cy.get('#editwave:visible').should('not.exist')
+
+        cy.get('#wave-list a.waveitem').should('have.length', 1).click()
+        cy.get('#wave-list a.waveitem.open').should('have.length', 1)
+        cy.get('form.add-message textarea').should('be.visible')
+
+        cy.get('form.add-message input[type=file]').selectFile(
+            [pngFile('a.png'), pngFile('b.png')],
+            { force: true }
+        )
+
+        cy.get('.attachment-chip').should('have.length', 2)
+        cy.get('.attachment-chip').first().should('contain', 'a.png')
+        cy.get('.attachment-chip').eq(1).should('contain', 'b.png')
+
+        cy.get('form.add-message textarea').type('look at these')
+        cy.get('form.add-message button.sendmsg').click()
+
+        cy.get('.message').should('have.length', 1)
+        cy.get('.message .message-attachment img.message-img').should('have.length', 2)
+        cy.get('.message .message-text').should('contain', 'look at these')
+
+        cy.get('.attachment-chip').should('not.exist')
+
+        cy.get('.message-attachment img.message-img').first()
+            .should('have.prop', 'naturalWidth')
+            .and('be.greaterThan', 0)
+
+        cy.get('.message-attachment img.message-img').first()
+            .should('have.attr', 'src')
+            .and('match', /^\/wave\/[a-f0-9]{24}\/file\/[a-f0-9]{24}\/[a-f0-9]{32}$/)
+    })
+
+    it('rejects non-image picks with an alert and no chip', () => {
+        cy.visit('http://localhost:8000/loginTest')
+        cy.get('input[name="username"]').type(`${userId + 1}{enter}`)
+
+        cy.get('#wave-list a.addwave').click()
+        cy.get('#editwave form input#editwave-title').type('Reject Test{enter}')
+        cy.get('#wave-list a.waveitem').click()
+        cy.get('form.add-message textarea').should('be.visible')
+
+        const alertStub = cy.stub().as('alert')
+        cy.on('window:alert', alertStub)
+
+        cy.get('form.add-message input[type=file]').selectFile({
+            contents: Cypress.Buffer.from('hello world'),
+            fileName: 'notes.txt',
+            mimeType: 'text/plain',
+        }, { force: true })
+
+        cy.get('@alert').should('have.been.calledOnce')
+        cy.get('.attachment-chip').should('not.exist')
+    })
+})

--- a/fly.toml
+++ b/fly.toml
@@ -15,6 +15,11 @@ kill_timeout = "5s"
   NODE_ENV = "production"
   NODE_MODULES_CACHE = "true"
   PORT = "8080"
+  UPLOAD_DIR = "/data/uploads"
+
+[[mounts]]
+  source = "uploads"
+  destination = "/data/uploads"
 
 [[services]]
   protocol = "tcp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0",
       "dependencies": {
+        "@types/multer": "^2.1.0",
         "body-parser": "^1.20.4",
         "connect-redis": "^7.1.1",
         "content-type": "^1.0.5",
@@ -26,6 +27,7 @@
         "metascraper-image": "^5.45.22",
         "metascraper-title": "^5.45.22",
         "mongoose": "^8.22.1",
+        "multer": "^2.1.1",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-local": "^1.0.0",
@@ -937,7 +939,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -959,7 +960,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1035,7 +1035,6 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1048,7 +1047,6 @@
       "version": "4.19.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
       "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1077,15 +1075,22 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.30",
@@ -1167,21 +1172,18 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1191,7 +1193,6 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1203,7 +1204,6 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -1517,6 +1517,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/arch": {
       "version": "2.2.0",
@@ -1835,6 +1841,23 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -2275,6 +2298,21 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/condense-whitespace": {
       "version": "2.0.0",
@@ -5467,6 +5505,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nan": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
@@ -6353,6 +6410,20 @@
         "node-gyp": "^11.2.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7094,6 +7165,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -7461,6 +7549,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -7599,6 +7693,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@types/passport": "^1.0.16",
         "@types/passport-google-oauth20": "^2.0.16",
         "@types/passport-local": "^1.0.38",
+        "concurrently": "^9.2.1",
         "cypress": "^13.15.0",
         "eslint": "^8.57.1",
         "nodemon": "^3.1.7",
@@ -2234,6 +2235,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -2312,6 +2328,31 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
     "node_modules/condense-whitespace": {
@@ -3022,6 +3063,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -3712,6 +3763,16 @@
       "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -6461,6 +6522,16 @@
         "throttleit": "^1.0.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -6634,10 +6705,11 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -6771,6 +6843,19 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -7489,6 +7574,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
@@ -8142,10 +8237,49 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "exports": "./code/dist/SurfServer.js",
   "license": "GPL-3.0",
   "dependencies": {
+    "@types/multer": "^2.1.0",
     "body-parser": "^1.20.4",
     "connect-redis": "^7.1.1",
     "content-type": "^1.0.5",
@@ -29,6 +30,7 @@
     "metascraper-image": "^5.45.22",
     "metascraper-title": "^5.45.22",
     "mongoose": "^8.22.1",
+    "multer": "^2.1.1",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "start": "node Surf.js",
     "dev": "tsc -p code/tsconfig.json --watch",
     "dev:server": "concurrently -k -n tsc,node -c blue,green \"tsc -p code/tsconfig.json --watch\" \"TESTMODE=1 nodemon --watch code/dist --ext js Surf.js\"",
-    "dev:react": "npm --prefix client-react run dev",
+    "dev:react": "npm --prefix client-react run build -- --watch",
+    "dev:all": "concurrently -k -n srv,react -c blue,magenta \"npm:dev:server\" \"npm:dev:react\"",
     "test": "vitest run --config code/vitest.config.ts",
     "test:watch": "vitest --config code/vitest.config.ts",
     "test:e2e": "cypress run"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "build": "tsc -p code/tsconfig.json",
     "start": "node Surf.js",
     "dev": "tsc -p code/tsconfig.json --watch",
+    "dev:server": "concurrently -k -n tsc,node -c blue,green \"tsc -p code/tsconfig.json --watch\" \"TESTMODE=1 nodemon --watch code/dist --ext js Surf.js\"",
+    "dev:react": "npm --prefix client-react run dev",
     "test": "vitest run --config code/vitest.config.ts",
     "test:watch": "vitest --config code/vitest.config.ts",
     "test:e2e": "cypress run"
@@ -61,6 +63,7 @@
     "@types/passport": "^1.0.16",
     "@types/passport-google-oauth20": "^2.0.16",
     "@types/passport-local": "^1.0.38",
+    "concurrently": "^9.2.1",
     "cypress": "^13.15.0",
     "eslint": "^8.57.1",
     "nodemon": "^3.1.7",


### PR DESCRIPTION
## Summary
- Users in a wave can upload a file via the React reply forms; all other wave members see it in real time.
- File metadata travels with the message (`storageKey`, `filename`, `mimeType`, `size`) and binary contents live on local disk at `<uploadDir>/<waveId>/<storageKey>`. Download is gated by wave membership.
- React only — the Backbone client is unchanged. The new optional `attachment` field is ignored by it.

## Design notes
- Upload is HTTP `POST /wave/:waveId/upload` (multipart, multer). It then calls the existing `wave.addMessage(msg)` so socket broadcast + unread tracking are reused — no new socket event.
- Download is HTTP `GET /wave/:waveId/file/:messageId`. Inline only for image/video/audio/pdf; everything else is forced to `application/octet-stream` + `Content-Disposition: attachment` to neutralize HTML/script payloads.
- Storage path is configurable via `UPLOAD_DIR`; default is `./uploads`. For Fly deploys, attach a volume there.
- Size cap is configurable via `MAX_UPLOAD_BYTES` (default 10 MiB).

## Test plan
- [x] `npm test` (90/90 green; new tests: `Storage` round-trip writes to a temp dir, `Message.validate` accepts attachment-only)
- [x] `npm run build` (backend tsc)
- [x] `npm --prefix client-react run build` (vite production build)
- [ ] Local smoke (manual, follow-up): start the server, log in via `/loginTest`, attach an image in a wave, confirm it appears for the uploader and a second logged-in user; attach a PDF, confirm download.
- [ ] Mongo migration: not needed — `attachment` is optional.

## Open items
- Single-VM Fly deploy: files vanish on redeploy unless a volume is mounted at `UPLOAD_DIR`. If the team plans horizontal scaling, swap the `Storage` module for an S3 implementation later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)