### PR TITLE
fix: open the wave of the most recent message on cold refresh

### DIFF
--- a/client-react/src/views/WavesView.tsx
+++ b/client-react/src/views/WavesView.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useShallow } from 'zustand/react/shallow'
 import { useWaveStore } from '@/stores/waveStore'
+import { useMessageStore } from '@/stores/messageStore'
 import { useAppStore } from '@/stores/appStore'
 import { t } from '@/utils/i18n'
 
@@ -11,10 +12,26 @@ export default function WavesView() {
   const openEditWave = useAppStore(state => state.openEditWave)
 
   useEffect(() => {
-    if (activeWaves.length > 0) {
-      const lastWave = activeWaves[activeWaves.length - 1]
-      navigate(`/wave/${lastWave._id}`)
+    if (activeWaves.length === 0) return
+
+    const activeIds = new Set(activeWaves.map(w => w._id))
+    const allMessages = useMessageStore.getState().allMessages()
+
+    let targetWaveId: string | null = null
+    if (allMessages.length > 0) {
+      const latest = allMessages.reduce((acc, msg) =>
+        msg.created_at > acc.created_at ? msg : acc
+      )
+      if (activeIds.has(latest.waveId)) {
+        targetWaveId = latest.waveId
+      }
     }
+
+    if (!targetWaveId) {
+      targetWaveId = activeWaves[activeWaves.length - 1]._id
+    }
+
+    navigate(`/wave/${targetWaveId}`)
   }, [activeWaves, navigate])
 
   return (


### PR DESCRIPTION
## Summary
- `WavesView` used to navigate to `activeWaves[activeWaves.length - 1]`, i.e. the wave with the highest `_id`. A newly created but quiet wave would win over a wave with fresh chatter.
- Match the Backbone behavior (`client/src/surf.js:32-42`): find the message with the latest `created_at`, navigate to its wave. Fallback chain unchanged when there are no messages.

The new effect only runs after `ready` arrives from the server (App.tsx gates `Outlet` on `ready`), so the message list is fully populated when we decide where to land.

## Test plan
- [ ] Two active waves; post a recent message into the older one. Hard refresh → should land in the older wave, not the newer one.
- [ ] No messages anywhere → falls back to last-wave-by-id (current behavior).
- [ ] Land directly on `#/wave/<id>` → no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)