### PR TITLE
feat: Google avatar and Gravatar options in Edit profile

### DIFF
--- a/client-react/src/components/EditUser.tsx
+++ b/client-react/src/components/EditUser.tsx
@@ -108,17 +108,50 @@ export default function EditUser() {
                 <div key={avatarName} className="avatar">
                   <label>
                     <img src={`/images/${avatarName}.png`} width="80" alt={avatarName} /><br />
-                    <input 
-                      type="radio" 
-                      value={avatarName} 
+                    <input
+                      type="radio"
+                      value={avatarName}
                       checked={avatar === avatarName}
                       onChange={(e) => setAvatar(e.target.value)}
-                      name="edituser-avatar-cb" 
+                      name="edituser-avatar-cb"
                       required
                     />
                   </label>
                 </div>
               ))}
+              {currentUser?.googleAvatar && (
+                <div className="avatar">
+                  <label>
+                    <img src={currentUser.googleAvatar} width="80" alt="Google avatar" /><br />
+                    <input
+                      type="radio"
+                      value={currentUser.googleAvatar}
+                      checked={avatar === currentUser.googleAvatar}
+                      onChange={(e) => setAvatar(e.target.value)}
+                      name="edituser-avatar-cb"
+                      required
+                    />
+                  </label>
+                </div>
+              )}
+              {currentUser?.emailMD5 && (() => {
+                const gravatarUrl = `https://secure.gravatar.com/avatar/${currentUser.emailMD5}?s=80&d=monsterid`
+                return (
+                  <div className="avatar">
+                    <label>
+                      <img src={gravatarUrl} width="80" alt="Gravatar" /><br />
+                      <input
+                        type="radio"
+                        value={gravatarUrl}
+                        checked={avatar === gravatarUrl}
+                        onChange={(e) => setAvatar(e.target.value)}
+                        name="edituser-avatar-cb"
+                        required
+                      />
+                    </label>
+                  </div>
+                )
+              })()}
             </div>
           </div>
           

--- a/client-react/src/types/index.ts
+++ b/client-react/src/types/index.ts
@@ -3,6 +3,8 @@ export interface User {
   name: string
   avatar: string
   status: 'online' | 'offline'
+  googleAvatar?: string
+  emailMD5?: string
   showPictures?: boolean
   showVideos?: boolean
   showLinkPreviews?: boolean


### PR DESCRIPTION
## Summary
- The Backbone client offered the user's Google profile picture and a Gravatar (monsterid fallback) alongside the built-in `head1..6` avatars. The React port only had the built-ins.
- Surface `googleAvatar` and `emailMD5` on the React `User` type (the server already sends them via `toSelfJSON`) and render the extra options in `EditUser` when present.
- Radio value is the full URL; `UserAvatar` already handled URL avatars, so no other component changes needed.

## Test plan
- [ ] Log in via Google → Edit profile shows two extra options (Google + Gravatar). Pick each, save, verify avatar updates everywhere.
- [ ] Log in via `/loginTest` (no `googleAvatar`, fake email) → only the Gravatar option appears, falling back to monsterid.
- [ ] An existing user whose stored `avatar` is a URL → that URL's radio is checked on open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)