### PR TITLE
refactor: simplify saveMessage (drop calcRootId backfill)

### DIFF
--- a/code/src/DAL.ts
+++ b/code/src/DAL.ts
@@ -120,48 +120,23 @@ class DataAccessLayer {
 
     if (message.parentId === null) {
       m.rootId = m._id;
-      await m.save();
     } else {
-      await m.save();
-      await this.calcRootId(message.parentId, [m]);
+      const parent = await MessageModel.findById(message.parentId, 'rootId').exec();
+      m.rootId = parent?.rootId ?? new Types.ObjectId(message.parentId);
     }
 
+    await m.save();
     message.setId(m._id.toString());
   }
 
   /**
-   * Calculate root ID recursively for message threading
+   * Resolve the rootId of a message by id. Assumes the rootId invariant holds
+   * (every message has rootId populated at save time).
    */
-  async calcRootId(
-    messageId: string, 
-    messages: MessageDocument[]
-  ): Promise<string | null> {
-    const message = await MessageModel.findById(messageId);
+  async getRootId(messageId: string): Promise<string | null> {
+    const message = await MessageModel.findById(messageId, 'rootId').exec();
     if (!message) return null;
-
-    // If knows root element, or IS a root element
-    if (message.rootId !== null || message.parentId === null) {
-      let rootId: Types.ObjectId | null = null;
-
-      if (message.rootId !== null) {
-        rootId = message.rootId;
-      } else if (message.parentId === null) {
-        rootId = message._id;
-        messages.push(message);
-      }
-
-      if (rootId) {
-        await MessageModel.updateMany(
-          { _id: { $in: messages.map(msg => msg._id) } },
-          { rootId }
-        ).exec();
-      }
-
-      return rootId?.toString() ?? null;
-    } else {
-      messages.push(message);
-      return this.calcRootId(message.parentId.toString(), messages);
-    }
+    return (message.rootId ?? message._id).toString();
   }
 
   /**

--- a/code/src/model/Wave.ts
+++ b/code/src/model/Wave.ts
@@ -178,7 +178,7 @@ export class Wave {
   ): Promise<void> {
     try {
       if (minParentId && maxRootId) {
-        const minRootId = await Registry.dal.calcRootId(minParentId, []);
+        const minRootId = await Registry.dal.getRootId(minParentId);
         const ids = await Registry.dal.getUnreadIdsForUserInWave(user, this);
         const msgs = await Registry.dal.getMessagesForUserInWave(this, minRootId, maxRootId, ids);
         user.send('message', { messages: msgs, waveId: this.id });


### PR DESCRIPTION
## Summary
`saveMessage` previously did: insert new message (no `rootId`) → walk up the parent chain with `calcRootId` → `updateMany` to backfill `rootId` on the new message *and* on any ancestors that hadn't been written with one.

That walk was a lazy backfill from when the `rootId` field was first introduced. The invariant has held since: every new message gets `rootId` at save time.

Collapse to one read + one write:
- Root message → `rootId = _id`, save.
- Reply → look up `parent.rootId` (single `findById` projecting `rootId`), set it on the new message, save.

Replaced `calcRootId(messageId, [])` with a smaller `getRootId(messageId)` for the one remaining caller (`Wave.sendPreviousMessagesToUser`), since it only needed to resolve a `parentId`'s `rootId` — no chain walk required when the invariant holds.

Net: -34 / +9 lines.

## Skipped (intentionally)
- No backfill migration. If any pre-invariant message exists with null `rootId` in prod, it'll stay broken; queries that sort by `rootId` would miss it. Per the conversation, we're assuming the DB is clean.

## Test plan
- [x] `npm run build`
- [x] `npm test` — 92/92
- [ ] Manual smoke after merge: post a new root message and a reply, refresh, confirm the wave loads with both messages threaded correctly (this is what `rootId` drives in `getLastMessagesForUserInWave` → `getMessagesForUserInWave`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)